### PR TITLE
Adding Docker build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.12-alpine as build
+ENV GOOS linux
+ENV GOARCH 386
+WORKDIR /usr/src/pipe-to-me
+COPY go.mod .
+RUN go mod download
+COPY *.go ./
+RUN go build
+
+FROM busybox
+COPY --from=build /usr/src/pipe-to-me/pipe-to-me /pipe-to-me
+EXPOSE 8080
+ENTRYPOINT ["/pipe-to-me", "-httpaddr", ":8080"]

--- a/Readme.md
+++ b/Readme.md
@@ -113,3 +113,11 @@ apt-get install python-certbot-nginx
 Generate and install a certificate with: `certbot --nginx -d pipeto.me`
 
 The certificate should auto-renew when necessary.
+
+### Docker
+
+A prepared Docker image is available [here](https://hub.docker.com/r/adamgoose/pipe-to-me).
+
+`docker run --name pipe-to-me -p 80:8080 adamgoose/pipe-to-me -baseurl http://localhost/`
+
+You can build the image yourself by running `docker-compose up --build`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  pipe-to-me:
+    build: .
+    image: adamgoose/pipe-to-me
+    ports:
+      - 8080:8080


### PR DESCRIPTION
These instructions build a very small Docker image (5Mb). The image is available at [adamgoose/pipe-to-me:latest](https://hub.docker.com/r/adamgoose/pipe-to-me). I can automate this build and I can continue to manage it if you make me a collaborator on this project, or you can easily set up automated builds at https://hub.docker.com.